### PR TITLE
fix(faq): link "how to start" and CTA to Salla app marketplace

### DIFF
--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -235,12 +235,14 @@ export default function FAQPage() {
             <p className="text-gray-600 mb-6">
               ابدأ بجمع تقييمات حقيقية بعد الشراء وانشرها بعلامة &ldquo;مشتري موثّق&rdquo;.
             </p>
-            <Link
-              href="/signup"
+            <a
+              href="https://apps.salla.sa/ar/app/1180703836"
+              target="_blank"
+              rel="noopener noreferrer"
               className="inline-block bg-green-700 text-white px-8 py-3 rounded-full text-md shadow-md hover:bg-green-800 hover:scale-105 transition-all duration-200"
             >
               ابدأ الآن
-            </Link>
+            </a>
           </div>
         </section>
 

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -143,13 +143,6 @@ const faqItems = [
             .
           </li>
         </ul>
-        <p>
-          أو ابدأ الآن من
-          <Link href="/signup" className="text-green-700 font-semibold hover:underline mr-1">
-            صفحة التسجيل
-          </Link>
-          .
-        </p>
       </div>
     ),
   },

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -113,13 +113,44 @@ const faqItems = [
   {
     q: 'كيف أبدأ؟',
     a: (
-      <p className="text-gray-700 leading-relaxed">
-        ثبّت تطبيق &quot;مشتري موثّق&quot; من سوق تطبيقات سلة، وسيبدأ النظام تلقائيًا بتوثيق تقييمات متجرك فور استلامها. ابدأ الآن من
-        <Link href="/signup" className="text-green-700 font-semibold hover:underline mr-1">
-          صفحة التسجيل
-        </Link>
-        .
-      </p>
+      <div className="text-gray-700 leading-relaxed space-y-3">
+        <p>
+          حمّل تطبيق &quot;مشتري موثّق&quot; من سوق تطبيقات سلة، وسيبدأ النظام تلقائيًا بتوثيق تقييمات متجرك فور استلامها.
+        </p>
+        <ul className="list-disc list-inside space-y-1">
+          <li>
+            تحميل التطبيق من{' '}
+            <a
+              href="https://apps.salla.sa/ar/app/1180703836"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-green-700 font-semibold hover:underline"
+            >
+              سوق تطبيقات سلة
+            </a>
+            .
+          </li>
+          <li>
+            شاهد{' '}
+            <a
+              href="https://youtube.com/shorts/s6gBXoANREY"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-green-700 font-semibold hover:underline"
+            >
+              طريقة الربط بالفيديو
+            </a>
+            .
+          </li>
+        </ul>
+        <p>
+          أو ابدأ الآن من
+          <Link href="/signup" className="text-green-700 font-semibold hover:underline mr-1">
+            صفحة التسجيل
+          </Link>
+          .
+        </p>
+      </div>
     ),
   },
 ];


### PR DESCRIPTION
## Summary

Follow-up to ahmedfarouk145/theqah#15. The FAQ now describes the Salla-native flow, but the onboarding entry points were still pointing to the internal signup page. This PR makes both the "كيف أبدأ؟" answer and the CTA button direct merchants to the real install path: Salla's app marketplace.

- **`src/pages/faq.tsx:113-149`** — Rewrote the "كيف أبدأ؟" answer as a short intro plus a bulleted list with two external links:
  - Install from [سوق تطبيقات سلة](https://apps.salla.sa/ar/app/1180703836)
  - Tutorial video: [طريقة الربط](https://youtube.com/shorts/s6gBXoANREY)
  - Removed the `/signup` fallback paragraph since the Salla marketplace is the only supported entry point now.
- **`src/pages/faq.tsx:238-246`** — The "ابدأ الآن" CTA button at the bottom of the page now opens the Salla app listing in a new tab (was linking to `/signup`).

All external links use `target="_blank" rel="noopener noreferrer"`.

## Test plan

- [ ] Load `/faq`, open "كيف أبدأ؟" and confirm the two bullet links open the correct Salla app page and YouTube tutorial in new tabs
- [ ] Scroll to the bottom CTA and confirm "ابدأ الآن" opens the Salla app listing (not `/signup`)
- [ ] Confirm no references to `/signup` remain in the "كيف أبدأ؟" answer

https://claude.ai/code/session_019mjqwL8WSF7Je8Ju5WqaBa