### PR TITLE
feat(home): replace "why us" stats with sourced research figures

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -255,28 +255,34 @@ export default function LandingPage({ appReviews }: InferGetStaticPropsType<type
                   emoji: '🎯',
                   color: 'from-amber-400 to-orange-500',
                   bgColor: 'bg-amber-50',
-                  title: 'حسم قرار الشراء',
-                  desc: 'إزالة تردد العميل لحظة الدفع ورفع معدل التحويل فوراً',
-                  stat: '+35%',
-                  statLabel: 'معدل التحويل'
+                  title: 'رفع احتمالية الشراء',
+                  desc: 'بمجرد وجود 5 تقييمات موثّقة',
+                  stat: '+270%',
+                  statLabel: 'احتمالية الشراء',
+                  source: 'Northwestern Spiegel',
+                  sourceUrl: 'https://spiegel.medill.northwestern.edu/how-online-reviews-influence-sales/',
                 },
                 {
                   emoji: '🛒',
                   color: 'from-blue-400 to-indigo-500',
                   bgColor: 'bg-blue-50',
-                  title: 'رفع قيمة السلة',
-                  desc: 'منح العميل الجرأة والثقة لشراء منتجات أغلى وبكميات أكثر',
-                  stat: '+28%',
-                  statLabel: 'قيمة الطلب'
+                  title: 'زيادة المبيعات المباشرة',
+                  desc: 'عند إضافة شارة "المشتري الموثّق"',
+                  stat: '+15%',
+                  statLabel: 'مبيعات مباشرة',
+                  source: 'AMA',
+                  sourceUrl: 'https://www.ama.org/marketing-news/the-power-of-verified-reviews-in-shaping-buying-decisions-and-building-brand-trust/',
                 },
                 {
                   emoji: '📈',
                   color: 'from-green-400 to-emerald-500',
                   bgColor: 'bg-green-50',
-                  title: 'مضاعفة نتائج الإعلانات',
-                  desc: 'تحويل الزوار الجدد إلى مشترين بسرعة بفضل ضمان طرف ثالث محايد',
-                  stat: '2x',
-                  statLabel: 'ROI الإعلانات'
+                  title: 'مضاعفة معدل التحويل',
+                  desc: 'للمنتجات مرتفعة السعر عند عرض تقييمات موثّقة',
+                  stat: '+380%',
+                  statLabel: 'معدل التحويل',
+                  source: 'Capital One Shopping',
+                  sourceUrl: 'https://capitaloneshopping.com/research/online-reviews-statistics/',
                 },
               ].map((item, i) => (
                 <div
@@ -298,6 +304,16 @@ export default function LandingPage({ appReviews }: InferGetStaticPropsType<type
                     </span>
                     <span className="text-gray-500 text-sm">{item.statLabel}</span>
                   </div>
+
+                  {/* Source */}
+                  <a
+                    href={item.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-3 inline-block text-xs italic text-gray-500 hover:text-green-700 hover:underline"
+                  >
+                    المصدر: {item.source}
+                  </a>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary

Replace the three marketing stat cards in the "لماذا مشتري موثّق = مبيعات أكثر" section on the homepage with figures backed by published research, and make each card show a clickable citation to the original source.

**`src/pages/index.tsx:252-323`** — New stat cards:

| Card | Stat | Source |
|---|---|---|
| رفع احتمالية الشراء — *بمجرد وجود 5 تقييمات موثّقة* | **+270%** | [Northwestern Spiegel](https://spiegel.medill.northwestern.edu/how-online-reviews-influence-sales/) |
| زيادة المبيعات المباشرة — *عند إضافة شارة "المشتري الموثّق"* | **+15%** | [AMA](https://www.ama.org/marketing-news/the-power-of-verified-reviews-in-shaping-buying-decisions-and-building-brand-trust/) |
| مضاعفة معدل التحويل — *للمنتجات مرتفعة السعر عند عرض تقييمات موثّقة* | **+380%** | [Capital One Shopping](https://capitaloneshopping.com/research/online-reviews-statistics/) |

Each card now renders a small italic "المصدر: {name}" link under the stat that opens the cited research in a new tab (`target="_blank" rel="noopener noreferrer"`). The card layout, emojis, gradient colors, hover animation, and section heading are unchanged.

## Test plan

- [ ] Load `/` and scroll to the "لماذا نحن؟" section
- [ ] Confirm the three cards show the new titles, descriptions, and stats (+270%, +15%, +380%)
- [ ] Click each "المصدر" link and confirm it opens the correct research URL in a new tab
- [ ] Confirm the card layout still looks correct on mobile (grid stacks to 1 column on small screens)

https://claude.ai/code/session_019mjqwL8WSF7Je8Ju5WqaBa