### PR TITLE
fix(reviews): resolve Zid store name and domain on reviews page

### DIFF
--- a/src/backend/server/services/store.service.ts
+++ b/src/backend/server/services/store.service.ts
@@ -53,12 +53,13 @@ export class StoreService {
 
 
         const s = data.salla || {};
-        const name = s.storeName ?? data.storeName ?? null;
+        const z = data.zid || {};
+        const name = s.storeName ?? z.storeName ?? data.storeName ?? null;
 
         return {
             storeUid: store.id || storeUid,
             name,
-            domain: s.domain ?? null,
+            domain: s.domain ?? z.domain ?? null,
             platform: data.platform ?? 'salla',
             salla: s,
         };


### PR DESCRIPTION
## Summary
- **Bug:** Zid store reviews page showed generic "تقييمات متجر" instead of the actual store name, and the store domain link was missing
- **Cause:** `getStoreInfo()` only checked `data.salla` for `storeName` and `domain`, ignoring `data.zid`
- **Fix:** Added `data.zid` as a fallback source in the name/domain resolution chain

## Test plan
- [ ] Verify a Zid store's reviews page now shows the correct store name in the heading
- [ ] Verify the store domain link appears for Zid stores
- [ ] Verify Salla store reviews pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)