### PR TITLE
feat(blog): per-post custom domain control

### DIFF
--- a/src/backend/server/types/blog.types.ts
+++ b/src/backend/server/types/blog.types.ts
@@ -17,10 +17,30 @@ export interface BlogPost {
     updatedAt: Timestamp;
     seoTitle?: string | null;
     seoDescription?: string | null;
+    /** Custom canonical host for this post (e.g. "blog.example.com"). Null = use site default. */
+    domain?: string | null;
     viewCount: number;
 }
 
 export type BlogPostInput = Omit<BlogPost, "id" | "createdAt" | "updatedAt" | "viewCount" | "publishedAt">;
+
+/**
+ * Normalize a user-supplied domain into a bare host (e.g. "blog.example.com").
+ * Strips protocol, trailing slashes, whitespace, and any path/query. Returns
+ * `null` for empty input or values that don't look like a host.
+ */
+export function normalizeDomain(input: unknown): string | null {
+    if (typeof input !== "string") return null;
+    const trimmed = input.trim();
+    if (!trimmed) return null;
+    const stripped = trimmed
+        .replace(/^https?:\/\//i, "")
+        .replace(/\/.*$/, "")
+        .replace(/:\d+$/, "")
+        .toLowerCase();
+    if (!/^[a-z0-9.-]+\.[a-z]{2,}$/.test(stripped)) return null;
+    return stripped;
+}
 
 export const BLOG_CATEGORIES = [
     "نصائح للتجار",

--- a/src/pages/api/blog/[id].ts
+++ b/src/pages/api/blog/[id].ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { requireBlogOwner } from "@/backend/server/auth/requireBlogOwner";
 import { dbAdmin } from "@/lib/firebaseAdmin";
 import { Timestamp } from "firebase-admin/firestore";
+import { normalizeDomain } from "@/backend/server/types/blog.types";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
@@ -31,7 +32,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const snap = await docRef.get();
         if (!snap.exists) return res.status(404).json({ error: "not found" });
 
-        const { title, excerpt, content, coverImage, author, category, tags, status, seoTitle, seoDescription } = req.body;
+        const { title, excerpt, content, coverImage, author, category, tags, status, seoTitle, seoDescription, domain } = req.body;
         const existing = snap.data()!;
         const now = Timestamp.now();
 
@@ -46,6 +47,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         if (tags !== undefined) updates.tags = tags;
         if (seoTitle !== undefined) updates.seoTitle = seoTitle;
         if (seoDescription !== undefined) updates.seoDescription = seoDescription;
+        if (domain !== undefined) {
+            if (typeof domain === "string" && domain.trim() && !normalizeDomain(domain)) {
+                return res.status(400).json({ error: "invalid domain" });
+            }
+            updates.domain = normalizeDomain(domain);
+        }
 
         if (status !== undefined) {
             updates.status = status;

--- a/src/pages/api/blog/index.ts
+++ b/src/pages/api/blog/index.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { requireBlogOwner } from "@/backend/server/auth/requireBlogOwner";
 import { dbAdmin } from "@/lib/firebaseAdmin";
 import { Timestamp } from "firebase-admin/firestore";
+import { normalizeDomain } from "@/backend/server/types/blog.types";
 
 function slugify(text: string): string {
     return text
@@ -34,10 +35,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     if (req.method === "POST") {
-        const { title, excerpt, content, coverImage, author, category, tags, status, seoTitle, seoDescription } = req.body;
+        const { title, excerpt, content, coverImage, author, category, tags, status, seoTitle, seoDescription, domain } = req.body;
 
         if (!title || !content) {
             return res.status(400).json({ error: "title and content are required" });
+        }
+
+        // Reject non-empty domains that fail to parse so the owner notices a
+        // typo immediately rather than silently saving an invalid host.
+        if (typeof domain === "string" && domain.trim() && !normalizeDomain(domain)) {
+            return res.status(400).json({ error: "invalid domain" });
         }
 
         const slug = slugify(title);
@@ -62,6 +69,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             updatedAt: now,
             seoTitle: seoTitle || null,
             seoDescription: seoDescription || null,
+            domain: normalizeDomain(domain),
             viewCount: 0,
         };
 

--- a/src/pages/api/public/blog/[slug].ts
+++ b/src/pages/api/public/blog/[slug].ts
@@ -48,5 +48,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         viewCount: (data.viewCount || 0) + 1,
         seoTitle: data.seoTitle || null,
         seoDescription: data.seoDescription || null,
+        domain: data.domain || null,
     });
 }

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -26,6 +26,8 @@ interface BlogPostFull {
     viewCount: number;
     seoTitle: string | null;
     seoDescription: string | null;
+    /** Owner-chosen canonical host (e.g. "blog.example.com"), or null to fall back to site default. */
+    domain: string | null;
 }
 
 /**
@@ -118,6 +120,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ params, re
         viewCount: (data.viewCount || 0) + 1,
         seoTitle: data.seoTitle || null,
         seoDescription: data.seoDescription || null,
+        domain: data.domain || null,
     };
 
     // Fetch related posts (same category, different slug)
@@ -163,7 +166,11 @@ function readingTime(html: string): number {
 export default function BlogPostPage({ post, related }: Props) {
     const pageTitle = post.seoTitle || post.title;
     const pageDesc = post.seoDescription || post.excerpt;
-    const canonicalUrl = `${URLS.CANONICAL_ORIGIN}/blog/${post.slug}`;
+    // When the owner set a custom domain for this post, use it as the canonical
+    // origin — this drives <link rel="canonical">, og:url, and JSON-LD @id so
+    // search engines & social crawlers attribute the post to the chosen host.
+    const postOrigin = post.domain ? `https://${post.domain}` : URLS.CANONICAL_ORIGIN;
+    const canonicalUrl = `${postOrigin}/blog/${post.slug}`;
     const ogImage = post.coverImage || `${URLS.CANONICAL_ORIGIN}/logo.png`;
 
     // BlogPosting JSON-LD — enriched for AI crawlers (ChatGPT Search, Perplexity,

--- a/src/pages/blog/manage.tsx
+++ b/src/pages/blog/manage.tsx
@@ -40,6 +40,7 @@ interface BlogPost {
     status: 'draft' | 'published';
     publishedAt?: unknown;
     createdAt?: unknown;
+    domain?: string | null;
     viewCount: number;
 }
 
@@ -64,6 +65,7 @@ export default function BlogManage() {
     const [uploadingCover, setUploadingCover] = useState(false);
     const [seoTitle, setSeoTitle] = useState('');
     const [seoDescription, setSeoDescription] = useState('');
+    const [domain, setDomain] = useState('');
     const coverInputRef = useRef<HTMLInputElement>(null);
 
     const handleCoverUpload = async (file: File) => {
@@ -130,6 +132,7 @@ export default function BlogManage() {
         setCoverImage('');
         setSeoTitle('');
         setSeoDescription('');
+        setDomain('');
         setEditingPost(null);
     };
 
@@ -148,6 +151,7 @@ export default function BlogManage() {
         setCoverImage(post.coverImage || '');
         setSeoTitle('');
         setSeoDescription('');
+        setDomain(post.domain || '');
         setEditingPost(post);
         setView('edit');
     };
@@ -161,7 +165,7 @@ export default function BlogManage() {
         try {
             const token = await getToken();
             const tags = tagsStr.split(/[,،]/).map((t) => t.trim()).filter(Boolean);
-            const payload = { title, excerpt, content, category, tags, author, coverImage: coverImage || null, status, seoTitle, seoDescription };
+            const payload = { title, excerpt, content, category, tags, author, coverImage: coverImage || null, status, seoTitle, seoDescription, domain: domain.trim() || null };
 
             if (editingPost) {
                 await axios.put(`/api/blog/${editingPost.id}`, payload, {
@@ -516,6 +520,20 @@ export default function BlogManage() {
                                             className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
                                             placeholder="وصف مخصص لمحركات البحث"
                                         />
+                                    </div>
+                                    <div>
+                                        <label className="block text-xs text-gray-500 mb-1">النطاق المخصص (Domain)</label>
+                                        <input
+                                            type="text"
+                                            dir="ltr"
+                                            value={domain}
+                                            onChange={(e) => setDomain(e.target.value)}
+                                            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono"
+                                            placeholder="blog.example.com"
+                                        />
+                                        <p className="text-[11px] text-gray-400 mt-1">
+                                            اترك الحقل فارغًا لاستخدام النطاق الافتراضي. عند تحديده سيُستخدم كـ canonical ورابط OpenGraph.
+                                        </p>
                                     </div>
                                 </div>
                             </details>


### PR DESCRIPTION
Let the blog owner set a custom canonical host per post. When present, the
domain drives <link rel="canonical">, og:url, and the JSON-LD @id on the
public post page so search engines and social crawlers attribute the post
to the chosen host. Empty leaves the site default in place.